### PR TITLE
Add locale message 2083 for fishing net users-only validation

### DIFF
--- a/init/en_localindex.dat
+++ b/init/en_localindex.dat
@@ -1202,6 +1202,7 @@ MSG2078=
 MSG2079=
 MSG208=There must be no more or less than three logs to make a campfire.
 MSG2080=
+MSG2083=You can only immobilize users with the net.
 MSG209=¬1 tried to steal from you!
 MSG21=Not available while riding
 MSG210=You have stabbed ¬1 for ¬2!
@@ -6836,7 +6837,7 @@ TARGETMSG=
 
 [INIT]
 NUMEROHECHIZO=339
-NUMLOCALEMSG=2080
+NUMLOCALEMSG=2083
 NUMMAPAS=750
 NUMNPCS=1459
 NUMOBJS=5067

--- a/init/sp_localindex.dat
+++ b/init/sp_localindex.dat
@@ -4746,7 +4746,7 @@ TARGETMSG=
 
 [INIT]
 NUMEROHECHIZO=339
-NUMLOCALEMSG=2080
+NUMLOCALEMSG=2083
 NUMMAPAS=750
 NUMNPCS=1459
 NUMOBJS=5067
@@ -47119,6 +47119,7 @@ MSG2078=
 MSG2079=
 MSG208=Debe haber no más ni menos de tres troncos para hacer una fogata.
 MSG2080=
+MSG2083=Solo puedes inmovilizar usuarios con la red.
 MSG209=¡¬1 ha intentado robarte!
 MSG21=No disponible cabalgando
 MSG210=¡Has apuñalado a ¬1 por ¬2!


### PR DESCRIPTION
- Increase NumLocaleMsg from 2080 to 2083 in SP/EN localindex files.
- Add MSG2083 for fishing net users-only feedback:
- SP: "Solo puedes inmovilizar usuarios con la red."
- EN: "You can only immobilize users with the net."
- Companion change for server PR (MsgNetOnlyUsers = 2083).